### PR TITLE
nginx: reduce Passenger workers

### DIFF
--- a/system/nginx.conf
+++ b/system/nginx.conf
@@ -7,6 +7,7 @@ events {
 http {
     passenger_root /home/rurema/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/passenger-4.0.37;
     passenger_ruby /home/rurema/.rbenv/versions/2.1.0/bin/ruby;
+    passenger_max_pool_size 2;
 
     include       mime.types;
     default_type  application/octet-stream;


### PR DESCRIPTION
docs.ruby-lang.org has only CPU cores. We don't need 6 (the default
max number of Passenger workers) processes. More workers use more
memory.
