### PR TITLE
Update URLs

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8"/>
 <title>Documentation for Ruby</title>
-<base href="http://docs.ruby-lang.org/en/"/>
+<base href="https://docs.ruby-lang.org/en/"/>
 <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css"/>
 </head>
 <body>

--- a/en/index.html
+++ b/en/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8"/>
 <title>Documentation for Ruby</title>
 <base href="https://docs.ruby-lang.org/en/"/>
-<link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css"/>
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 </head>
 <body>
 <div class="container">

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8"/>
 <title>docs.ruby-lang.org</title>
 <base href="https://docs.ruby-lang.org/"/>
-<link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css"/>
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 </head>
 <body>
 <div class="container">

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8"/>
 <title>docs.ruby-lang.org</title>
-<base href="http://docs.ruby-lang.org/"/>
+<base href="https://docs.ruby-lang.org/"/>
 <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css"/>
 </head>
 <body>

--- a/ja/index.html
+++ b/ja/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8"/>
 <title>プログラミング言語 Ruby リファレンスマニュアル</title>
 <base href="https://docs.ruby-lang.org/ja/"/>
-<link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"/>
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 </head>
 <body>
 <div class="container">

--- a/ja/index.html
+++ b/ja/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8"/>
 <title>プログラミング言語 Ruby リファレンスマニュアル</title>
-<base href="http://docs.ruby-lang.org/ja/"/>
+<base href="https://docs.ruby-lang.org/ja/"/>
 <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"/>
 </head>
 <body>

--- a/system/bc-static-all
+++ b/system/bc-static-all
@@ -28,7 +28,7 @@ def create_document(version)
          "--templatedir=#{TEMPLATE}",
          "--catalog=#{CATALOG}",
          "--fs-casesensitive",
-         "--canonical-base-url=http://docs.ruby-lang.org/ja/latest/",
+         "--canonical-base-url=https://docs.ruby-lang.org/ja/latest/",
          "--quiet")
   `rm -rf #{DOC_ROOT}/#{version}`
   `mv /var/rubydoc/tmp/#{version} #{DOC_ROOT}`


### PR DESCRIPTION
- Use https instead of http for docs.ruby-lang.org
- Update URL of Bootstrap CDN