### PR TITLE
Support of Ruby 2.1 has ended

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -16,7 +16,7 @@
     <a class="list-group-item" href="./2.4.0/">Ruby 2.4.0</a>
     <a class="list-group-item" href="./2.3.0/">Ruby 2.3.0</a>
     <a class="list-group-item" href="./2.2.0/">Ruby 2.2.0</a>
-    <a class="list-group-item" href="./2.1.0/">Ruby 2.1.0</a>
+    <a class="list-group-item" href="./2.1.0/">Ruby 2.1.0 (outdated)</a>
     <a class="list-group-item" href="./2.0.0/">Ruby 2.0.0 (outdated)</a>
     <a class="list-group-item" href="./1.9.3/">Ruby 1.9.3 (outdated)</a>
     <a class="list-group-item" href="./1.8.7/">Ruby 1.8.7 (outdated)</a>

--- a/ja/index.html
+++ b/ja/index.html
@@ -19,7 +19,6 @@
     <a class="list-group-item" href="./2.4.0/doc/index.html">Ruby 2.4</a>
     <a class="list-group-item" href="./2.3.0/doc/index.html">Ruby 2.3</a>
     <a class="list-group-item" href="./2.2.0/doc/index.html">Ruby 2.2</a>
-    <a class="list-group-item" href="./2.1.0/doc/index.html">Ruby 2.1</a>
     <div class="list-group-item list-group-item-info">
       <strong>注：</strong> Rubyは2.1.0から<a href='https://www.ruby-lang.org/ja/news/2013/12/21/semantic-versioning-after-2-1-0/'>Semantic Versioning</a>を採用しています。
       Ruby 2.1.1, 2.1.2等はバグ修正やセキュリティfixのみを含むため、リファレンスとしては2.1に統一しています。
@@ -28,9 +27,10 @@
   </div>
   <h2>Other versions</h2>
   <div class="list-group">
-    <a class="list-group-item" href="./2.0.0/doc/index.html">2.0.0 (2016/02/24 サポート終了)</a>
-    <a class="list-group-item" href="./1.9.3/doc/index.html">1.9.3 (2015/02/23 サポート終了)</a>
-    <a class="list-group-item" href="./1.8.7/doc/index.html">1.8.7 (2013/06/30 サポート終了)</a>
+    <a class="list-group-item" href="./2.1.0/doc/index.html">Ruby 2.1 (2017/04/01 サポート終了)</a>
+    <a class="list-group-item" href="./2.0.0/doc/index.html">Ruby 2.0.0 (2016/02/24 サポート終了)</a>
+    <a class="list-group-item" href="./1.9.3/doc/index.html">Ruby 1.9.3 (2015/02/23 サポート終了)</a>
+    <a class="list-group-item" href="./1.8.7/doc/index.html">Ruby 1.8.7 (2013/06/30 サポート終了)</a>
     <a class="list-group-item" href="http://doc.okkez.net/">http://doc.okkez.net/</a>
   </div>
   <h2>Project Page</h2>


### PR DESCRIPTION
- https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/
- https://www.ruby-lang.org/ja/news/2017/04/01/support-of-ruby-2-1-has-ended/