### PR TITLE
Update output directory to follow 5ec88c9. (fix #33)

### DIFF
--- a/system/bc-static-all
+++ b/system/bc-static-all
@@ -17,7 +17,7 @@ CATALOG="#{BITCLUST_DATA}/catalog"
 
 REF_BASE = "/var/rubydoc/doctree/refm"
 
-DOC_ROOT = "/var/www/docs.ruby-lang.org/shared/ja"
+DOC_ROOT = "/var/www/docs.ruby-lang.org/shared/public/ja"
 
 def create_document(version)
   system(RUBY, "-I#{BITCLUST_LIB_DIR}",

--- a/system/rdoc-static-all
+++ b/system/rdoc-static-all
@@ -7,7 +7,7 @@ VERSIONS = %w[
   trunk
 ]
 
-DOC_ROOT = "/var/www/docs.ruby-lang.org/shared/en"
+DOC_ROOT = "/var/www/docs.ruby-lang.org/shared/public/en"
 
 def create_document(version)
   system("bundle", "exec", "rake", "update:#{version}")


### PR DESCRIPTION
#33 で調べていた更新が行われない問題について、 5ec88c9 で以下になるようなsymlinkになったようなので、生成スクリプトも追従してみました。

* /var/www/docs.ruby-lang.org/current/public/ja/ -> /var/www/docs.ruby-lang.org/shared/public/{ja,en}/\<ver\>

