### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Directory structure
 
-* All of applications runs at `rurema` user.
+* All applications run at `rurema` user.
 * rurema-search: `/var/rubydoc`
 * docs.ruby-lang.org: `/var/www/docs.ruby-lang.org`
 * nginx configuration: `/etc/nginx/sites-available/docs.ruby-lang.org`


### PR DESCRIPTION
複数形なので、三単現の s はいらないと思いました。
all of は調べてみると all of 単数形 だったり、意味がちょっと違うかなと思ったので、of をとってみました。