### PR TITLE
RDoc 6.0.0.beta2 early adoption

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'rdoc'
+gem 'rdoc','>= 6.0.0.beta2'
 gem 'capistrano'
 gem 'capistrano-bundler'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
       ffi
     rbnacl-libsodium (1.0.11)
       rbnacl (>= 3.0.1)
-    rdoc (5.1.0)
+    rdoc (6.0.0.beta2)
     sshkit (1.14.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
@@ -36,7 +36,7 @@ DEPENDENCIES
   capistrano-bundler
   rbnacl (< 5.0.0)
   rbnacl-libsodium
-  rdoc
+  rdoc (>= 6.0.0.beta2)
 
 BUNDLED WITH
    1.15.3


### PR DESCRIPTION
We hit a bug in RDoc 5.1.0 #40. It has been fixed in 6.0.0 which gonna have released soon, so let's adopt it early, instead of workaround. Another point that I recommend this early adoption is, the RDoc of Ruby itself is very big and historic, so we might find additional bugs in 6.0.0 beta, before the final release.

Confirmed generating trunk with Ruby 2.3 succeeds.

----

Closes #40 