### PR TITLE
Ruby 2.3サポート終了

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,6 @@ versions = {
   "2.6.0" => "ruby_2_6",
   "2.5.0" => "ruby_2_5",
   "2.4.0" => "ruby_2_4",
-  "2.3.0" => "ruby_2_3",
 }
 
 versions.each do |version, branch_name|

--- a/public/en/index.html
+++ b/public/en/index.html
@@ -24,7 +24,7 @@
     <a class="list-group-item" href="./2.6.0/">Ruby 2.6.0</a>
     <a class="list-group-item" href="./2.5.0/">Ruby 2.5.0</a>
     <a class="list-group-item" href="./2.4.0/">Ruby 2.4.0</a>
-    <a class="list-group-item" href="./2.3.0/">Ruby 2.3.0</a>
+    <a class="list-group-item" href="./2.3.0/">Ruby 2.3.0 (outdated)</a>
     <a class="list-group-item" href="./2.2.0/">Ruby 2.2.0 (outdated)</a>
     <a class="list-group-item" href="./2.1.0/">Ruby 2.1.0 (outdated)</a>
     <a class="list-group-item" href="./2.0.0/">Ruby 2.0.0 (outdated)</a>

--- a/public/ja/index.html
+++ b/public/ja/index.html
@@ -27,7 +27,6 @@
     <a class="list-group-item" href="./2.6.0/doc/index.html">Ruby 2.6</a>
     <a class="list-group-item" href="./2.5.0/doc/index.html">Ruby 2.5</a>
     <a class="list-group-item" href="./2.4.0/doc/index.html">Ruby 2.4</a>
-    <a class="list-group-item" href="./2.3.0/doc/index.html">Ruby 2.3</a>
     <div class="list-group-item list-group-item-info">
       <strong>注：</strong> Rubyは2.1.0から<a href='https://www.ruby-lang.org/ja/news/2013/12/21/semantic-versioning-after-2-1-0/'>Semantic Versioning</a>を採用しています。
       Ruby 2.1.1, 2.1.2等はバグ修正やセキュリティfixのみを含むため、リファレンスとしては2.1に統一しています。
@@ -36,6 +35,7 @@
   </div>
   <h2>Other versions</h2>
   <div class="list-group">
+    <a class="list-group-item" href="./2.3.0/doc/index.html">Ruby 2.3 (2019/04/01 サポート終了)</a>
     <a class="list-group-item" href="./2.2.0/doc/index.html">Ruby 2.2 (2018/04/01 サポート終了)</a>
     <a class="list-group-item" href="./2.1.0/doc/index.html">Ruby 2.1 (2017/04/01 サポート終了)</a>
     <a class="list-group-item" href="./2.0.0/doc/index.html">Ruby 2.0.0 (2016/02/24 サポート終了)</a>

--- a/system/bc-setup-all
+++ b/system/bc-setup-all
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
 VERSIONS = %w[
-  2.3.0
   2.4.0
   2.5.0
   2.6.0

--- a/system/bc-static-all
+++ b/system/bc-static-all
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
 VERSIONS = %w[
-  2.3.0
   2.4.0
   2.5.0
   2.6.0

--- a/system/rdoc-static-all
+++ b/system/rdoc-static-all
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
 VERSIONS = %w[
-  2.3.0
   2.4.0
   2.5.0
   2.6.0


### PR DESCRIPTION
outdatedへの移動や生成の停止を行いました。マージは4月になってからの予定です。(#55 参照
