### PR TITLE
Update link to mirror site

### DIFF
--- a/public/ja/index.html
+++ b/public/ja/index.html
@@ -40,7 +40,7 @@
     <a class="list-group-item" href="./2.3.0/doc/index.html">Ruby 2.3 (2019/04/01 サポート終了)</a>
     <a class="list-group-item" href="./2.2.0/doc/index.html">Ruby 2.2 (2018/04/01 サポート終了)</a>
     <a class="list-group-item" href="./2.1.0/doc/index.html">Ruby 2.1 (2017/04/01 サポート終了)</a>
-    <a class="list-group-item" href="http://doc.okkez.net/">http://doc.okkez.net/</a>
+    <a class="list-group-item" href="https://rurema.clear-code.com/">https://rurema.clear-code.com/</a>
   </div>
   <h2>Project Page</h2>
   <div class="list-group">


### PR DESCRIPTION
http://doc.okkez.net/ は 2.4.0 で更新が止まっているようなのでリンクを変更したいです。
https://rurema.clear-code.com/ は 2.1.0 からのドキュメントがあって、 https://docs.ruby-lang.org/ja/search/ の 2.3.0 からよりは広いので、代わりのサイトとして適していると思います。

@okkez どうでしょうか?

この方針で良さそうなら、関連して https://www.ruby-lang.org/ja/documentation/ も変更したいと思っています。