### PR TITLE
Run rdoc in source directory, fixes rdoc-ref usage in documentation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,16 +35,16 @@ versions.each do |version, branch_name|
 
   namespace :rdoc do
     lang_version = File.join("en", version)
-    RDoc::Task.new(lang_version) do |rdoc|
-      rdoc.title = "Documentation for Ruby #{version}"
-      rdoc.main = "README.md"
-      rdoc.rdoc_dir = version
-      rdoc.rdoc_files << source_dir
-      rdoc.options << "-U"
-      rdoc.options << "--all"
-      rdoc.options << "--root=#{source_dir}"
-      rdoc.options << "--page-dir=#{source_dir}/doc"
-      rdoc.options << "--encoding=UTF-8"
+    task lang_version do
+      sh(
+        "rdoc",
+        "--title", "Documentation for Ruby #{version}",
+        "--main", "README.md",
+        "--output", "../../public/en/#{version}",
+        "-U", "--all", "--encoding=UTF-8",
+        ".",
+        chdir: source_dir
+      )
     end
   end
   task "rdoc:#{version}" => ["update:#{version}", "compile:#{version}"]


### PR DESCRIPTION
Previously, the rdoc was not run from inside the source directory,
resulting in rdoc-ref usage in the documentation not linking
correctly.

This uses a separate rdoc process for each ruby version, that runs
in the source directory for the version, and results in working
rdoc-ref links.

I'm not sure if the `--output` command is correct.  I don't think
it matches the previous location, but assuming that `public` is
the website root directory, it should be correct.  This drops the
`--page-dir` option, which is no longer needed with current
rdoc.

This should fix the issue mentioned in
https://github.com/ruby/ruby/pull/3421#issuecomment-674528444