### PR TITLE
Output to ./version instead of public/en/version directly

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -40,7 +40,7 @@ versions.each do |version, branch_name|
         "rdoc",
         "--title", "Documentation for Ruby #{version}",
         "--main", "README.md",
-        "--output", "../../public/en/#{version}",
+        "--output", "#{Dir.pwd}/#{version}",
         "-U", "--all", "--encoding=UTF-8",
         ".",
         chdir: source_dir

--- a/system/rdoc-static-all
+++ b/system/rdoc-static-all
@@ -13,7 +13,7 @@ Dir.chdir(File.join(__dir__, '..'))
 
 def create_document(version)
   system("bundle", "exec", "rake", "update:#{version}") or raise
-  system("rm", "-rf", "en/#{version}") or raise
+  system("rm", "-rf", version) or raise
   system("bundle", "exec", "rake", "rdoc:en/#{version}") or raise
   system("rsync", "-acvi", "--no-times", "--delete", version, DOC_ROOT) or raise
   system("rm", "-rf", version) or raise


### PR DESCRIPTION
It causes error when public/en/version is empty.
And old documents should not change when rdoc failed.