### PR TITLE
Fixup #122

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,7 @@ versions.each do |version, branch_name|
   task "compile:#{version}" => source_dir do
     Dir.chdir source_dir do
       sh "make clean" if File.exist?("Makefile")
-      sh "autoconf && ./configure && make"
+      sh "autoconf && ./configure --disable-install-doc && make"
     end
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,7 @@ versions.each do |version, branch_name|
 
   namespace :rdoc do
     lang_version = File.join("en", version)
-    task lang_version do
+    task lang_version => "compile:#{version}" do
       sh(
         "make", "html",
         "RDOCOPTS=--title=\"Documentation for Ruby #{version}\"" \


### PR DESCRIPTION
`make task` depends on compiled ruby. I added this.

