### PR TITLE
Stop generating docs for Ruby 2.5 and 2.6

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,6 @@ versions = {
   "3.1" => "ruby_3_1",
   "3.0" => "ruby_3_0",
   "2.7.0" => "ruby_2_7",
-  "2.6.0" => "ruby_2_6",
 }
 
 def sh_with_unbundled_env(...)

--- a/system/bc-setup-all
+++ b/system/bc-setup-all
@@ -3,8 +3,6 @@
 require 'fileutils'
 
 VERSIONS = %w[
-  2.5.0
-  2.6.0
   2.7.0
   3.0
   3.1

--- a/system/bc-static-all
+++ b/system/bc-static-all
@@ -1,8 +1,6 @@
 #!/usr/bin/env ruby
 
 VERSIONS = %w[
-  2.5.0
-  2.6.0
   2.7.0
   3.0
   3.1

--- a/system/rdoc-static-all
+++ b/system/rdoc-static-all
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
 VERSIONS = %w[
-  2.6.0
   2.7.0
   3.0
   3.1


### PR DESCRIPTION
Ruby 2.5 and 2.6 are EOL