### PR TITLE
fix bloken link of semantic versioning

### DIFF
--- a/public/ja/index.html
+++ b/public/ja/index.html
@@ -29,7 +29,7 @@
     <a class="list-group-item" href="./3.1/doc/index.html">Ruby 3.1</a>
     <a class="list-group-item" href="./3.0/doc/index.html">Ruby 3.0</a>
     <div class="list-group-item list-group-item-info">
-      <strong>注：</strong> Rubyは2.1.0から<a href='https://www.ruby-lang.org/ja/news/2013/12/21/semantic-versioning-after-2-1-0/'>Semantic Versioning</a>を採用しています。
+      <strong>注：</strong> Rubyは2.1.0から<a href='https://www.ruby-lang.org/ja/news/2013/12/21/ruby-version-policy-changes-with-2-1-0/'>Semantic Versioning</a>を採用しています。
       Ruby 2.1.1, 2.1.2等はバグ修正やセキュリティfixのみを含むため、リファレンスとしては2.1に統一しています。
     </div>
     <a class="list-group-item" href="./search/">るりまサーチ (全文検索)</a>


### PR DESCRIPTION
対象のページ: https://docs.ruby-lang.org/ja/

![image](https://github.com/ruby/docs.ruby-lang.org/assets/81596063/40aa2d78-0619-4dff-9f25-6138851e40d9)

現在、「Semantic Versioning 」のリンクには、https://www.ruby-lang.org/ja/news/2013/12/21/semantic-versioning-after-2-1-0/ が設定されています。しかし、リンク先は404です。

そこで正しいと思われる https://www.ruby-lang.org/ja/news/2013/12/21/ruby-version-policy-changes-with-2-1-0/ への置き換えを提案します。