### PR TITLE
[EN] Split the versions into supported/unsupported

### DIFF
--- a/public/en/index.html
+++ b/public/en/index.html
@@ -24,15 +24,17 @@
     <a class="list-group-item" href="./3.3/">Ruby 3.3</a>
     <a class="list-group-item" href="./3.2/">Ruby 3.2</a>
     <a class="list-group-item" href="./3.1/">Ruby 3.1</a>
-    <a class="list-group-item" href="./3.0/">Ruby 3.0</a>
-    <a class="list-group-item" href="./2.7.0/">Ruby 2.7.0</a>
-    <a class="list-group-item" href="./2.6.0/">Ruby 2.6.0 (outdated)</a>
-    <a class="list-group-item" href="./2.5.0/">Ruby 2.5.0 (outdated)</a>
-    <a class="list-group-item" href="./2.4.0/">Ruby 2.4.0 (outdated)</a>
-    <a class="list-group-item" href="./2.3.0/">Ruby 2.3.0 (outdated)</a>
-    <a class="list-group-item" href="./2.2.0/">Ruby 2.2.0 (outdated)</a>
-    <a class="list-group-item" href="./2.1.0/">Ruby 2.1.0 (outdated)</a>
-    <a class="list-group-item" href="./2.0.0/">Ruby 2.0.0 (outdated)</a>
+  </div>
+  <h2>Other versions</h2>
+  <div class="list-group">
+    <a class="list-group-item" href="./3.0/">Ruby 3.0 (End of Support 2024-04)</a>
+    <a class="list-group-item" href="./2.7.0/">Ruby 2.7 (End of Support 2023-04)</a>
+    <a class="list-group-item" href="./2.6.0/">Ruby 2.6 (End of Support 2022-04)</a>
+    <a class="list-group-item" href="./2.5.0/">Ruby 2.5 (End of Support 2021-04)</a>
+    <a class="list-group-item" href="./2.4.0/">Ruby 2.4 (End of Support 2020-04)</a>
+    <a class="list-group-item" href="./2.3.0/">Ruby 2.3 (End of Support 2019-04)</a>
+    <a class="list-group-item" href="./2.2.0/">Ruby 2.2 (End of Support 2018-04)</a>
+    <a class="list-group-item" href="./2.1.0/">Ruby 2.1 (End of Support 2017-04)</a>
   </div>
 </div>
 </body>

--- a/public/en/index.html
+++ b/public/en/index.html
@@ -17,7 +17,7 @@
 <body>
 <div class="container">
   <div class="page-header">
-    <h1>Documentation for Ruby</h1>
+    <h1>Ruby Programming Language Documentation</h1>
   </div>
   <div class="list-group">
     <a class="list-group-item" href="./master/">Ruby master</a>


### PR DESCRIPTION
I like the recent changes and wanted to also see the End of Support dates grouped into a different list like the JA version.

<img width="1008" alt="Screenshot 2024-12-03 at 9 59 20 AM" src="https://github.com/user-attachments/assets/f9b45b5c-39f0-49dc-8a34-6e6c00c71c28">
