### PR TITLE
Add 3.4 to rdoc-static-all's list

### DIFF
--- a/system/rdoc-static-all
+++ b/system/rdoc-static-all
@@ -5,6 +5,7 @@ VERSIONS = %w[
   3.1
   3.2
   3.3
+  3.4
   master
 ]
 


### PR DESCRIPTION
I can confirm that 3.4's doc is uploaded properly, but without this it doesn't get pulled down to `docs.ruby-lang.org/en`.