### PR TITLE
静的 /ja/search/ ページを配信対象に追加し、トップのリンク文言を更新する

### DIFF
--- a/conf/docs.ruby-lang.org
+++ b/conf/docs.ruby-lang.org
@@ -1,9 +1,3 @@
-    # define limit zone
-    #limit_req_zone $binary_remote_addr zone=search_limit:10m rate=1r/s;
-    limit_req_zone global zone=search_limit:10m rate=2r/s;
-
-    passenger_max_pool_size 2;
-
     server {
         listen 80;
         server_name doc.ruby-lang.org;
@@ -113,39 +107,25 @@
             add_header Surrogate-Key "doxygen-latest-html";
         }
 
-        location ~ ^/ja/search/.*/query:.*/query:.*/query:.*/query:.*/query:.*/ {
-            return 414;
-        }
-
-        location /ja/search {
-            limit_req zone=search_limit burst=1 nodelay;
-            limit_req_status 429;
-            proxy_pass http://localhost:9292;
-        }
-
-        location ~ /ja/search/(css|javascripts) {
-          rewrite ^/ja/search/(.+)$ /$1 break;
-          root /var/rubydoc/rurema-search/current/public;
-          add_header Cache-Control "public, max-age=43200, s-maxage=172800, stale-while-revalidate=86400, stale-if-error=604800";
-          add_header Surrogate-Key "rurema-search-assets";
+        # /ja/search/ は rurema-search（サーバアプリ）から全バージョン対応の
+        # 静的検索ページに置き換えた（rurema/generated-documents の
+        # html/ja/search を system/bc-static-all が rsync し、他の版と同じく
+        # location / の root から配信される）。
+        # 旧 rurema-search の /ja/search/query:語/ 形式は ?q= に読み替えて
+        # リダイレクトする。version: 等の他のファセットは落とす（静的ページは
+        # 全バージョン横断）。$request_uri ベースのキャプチャなので
+        # percent-encoding は保たれる
+        location ~ ^/ja/search/.*query: {
+            if ($request_uri ~ "^/ja/search/(?:[^?]*?/)??query:([^/?]+)") {
+                return 301 /ja/search/?q=$1;
+            }
+            return 301 /ja/search/;
         }
 
         error_page   500 502 503 504  /50x.html;
         location = /50x.html {
             root   /usr/share/nginx/html;
         }
-    }
-
-    server {
-        listen       9292;
-        server_name  localhost;
-        root /var/rubydoc/rurema-search/current/public;
-        passenger_enabled on;
-        passenger_max_requests 50000;
-
-        # add_header Cache-Control "private";
-        add_header Cache-Control "public, max-age=3600, s-maxage=172800, stale-while-revalidate=86400, stale-if-error=60";
-        add_header Surrogate-Key "rurema-search-app";
     }
 
     server {

--- a/public/ja/index.html
+++ b/public/ja/index.html
@@ -34,7 +34,7 @@
       Ruby 2.1.1, 2.1.2等はバグ修正やセキュリティfixのみを含むため、リファレンスとしては2.1に統一しています。
     </div>
 -->
-    <a class="list-group-item" href="./search/">るりまサーチ (全文検索)</a>
+    <a class="list-group-item" href="./search/">リファレンス検索 (クラス・メソッド名、全バージョン)</a>
   </div>
   <h2>Other versions</h2>
   <div class="list-group">

--- a/system/bc-static-all
+++ b/system/bc-static-all
@@ -20,8 +20,10 @@ GENERATED_DOCUMENTS_BASE = "/var/rubydoc/generated-documents"
 
 Dir.glob("#{GENERATED_DOCUMENTS_BASE}/html/ja/*") do |version_path|
   version = File.basename(version_path)
-  next unless /\A\d/.match?(version)
-  VERSIONS.push version
+  # "search" は全バージョン対応の静的検索ページ（rurema-search 置き換え）。
+  # latest/master の symlink 計算には含めない
+  next unless /\A\d/.match?(version) || version == "search"
+  VERSIONS.push version if /\A\d/.match?(version)
   system("rsync", "-acvi", "--no-times", "--delete", version_path, DOC_ROOT) or raise
   system('./system/fastly-purge-key', '--soft', "ja/#{version}")
 end


### PR DESCRIPTION
## 概要

るりまサーチ（rurema-search）を全バージョン対応の静的検索ページで置き換える配信側の変更です（生成側: rurema/bitclust#198 → rurema/generated-documents#137）。

1. **`system/bc-static-all`**: rurema/generated-documents が生成する `html/ja/search/` を rsync 対象に追加します。`search` は `latest`/`master` symlink の計算（VERSIONS）には含めません。
2. **`public/ja/index.html`**: 「るりまサーチ (全文検索)」→「リファレンス検索 (クラス・メソッド名、全バージョン)」。URL は `./search/` のまま静的ページが同じ場所に配置されるため、リンク先の変更はありません。
3. **`conf/docs.ruby-lang.org`（nginx）**: `/ja/search/` の rurema-search 一式（passenger アプリへの proxy + rate limit + 専用アセット配信 + :9292 サーバ + `limit_req_zone`/`passenger_max_pool_size`）を撤去し、rsync された静的ページを `location /` の root から配信します。旧 URL の互換として `/ja/search/query:語/` 形式を `?q=` に読み替えて 301 リダイレクトします:
   - `$request_uri` ベースのキャプチャで percent-encoding を保持（`query:%E9%85%8D%E5%88%97` → `?q=%E9%85%8D%E5%88%97`）
   - `version:` 等の他ファセットは落とします（静的ページは全バージョン横断で、結果に各バージョンへのリンクが付きます）
   - 多段 `query:` は最初の語を採用（`(?:[^?]*?/)??` の lazy-optional で `version:3.4/query:each` の順でも対応）
   - 静的ページ自体は `?q=` / `?query=` も解釈します

## 適用順序

1. rurema/bitclust#198（searchpage サブコマンド）
2. rurema/generated-documents#137 → daily ビルドで `html/ja/search/` がコミットされる
3. 本 PR をマージし、`system/bc-static-all` の実行で静的ページが配置されてから nginx 設定を適用（先に nginx を切り替えると `/ja/search/` が 404 になります）

## 置き換え後

- 検索は名前検索のみ（クラス・モジュール・メソッド・ライブラリ・特殊変数・ドキュメント名、全バージョン横断）。本文の全文検索とサジェストは提供せず、ページ内に外部検索エンジンの site: 検索を案内しています
- rurema-search アプリは停止可能になります（`system/update-rurema-index` 等の撤去、ruby/rurema-search リポジトリのアーカイブは別途）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
