### PR TITLE
/ja/ と /en/ の一覧に古いバージョンを追加し、3.2 を EOL 扱いに・robots.txt の /ja/search/ Disallow を撤廃

### DIFF
--- a/conf/docs.ruby-lang.org
+++ b/conf/docs.ruby-lang.org
@@ -94,6 +94,21 @@
               return 301 https://docs.ruby-lang.org/$1/3.0$2;
             }
 
+            # 旧 rurema-search の /ja/search/query:語/ 形式は ?q= に読み替えて
+            # リダイレクトする。version: 等の他のファセットは落とす（静的
+            # 検索ページは全バージョン横断）。$request_uri ベースのキャプチャ
+            # なので percent-encoding は保たれる。
+            # 注意: この location は prefix の location / にネストし、下の
+            # ^/(en|ja)/(.+?)/ より前に置く必要がある。マッチした prefix
+            # location 内のネスト regex が server 直下の regex location より
+            # 先に評価されるため、server 直下に置くと到達しない
+            location ~ ^/ja/search/.*query: {
+              if ($request_uri ~ "^/ja/search/(?:[^?]*?/)??query:([^/?]+)") {
+                return 301 /ja/search/?q=$1;
+              }
+              return 301 /ja/search/;
+            }
+
             location ~ ^/(en|ja)/(.+?)/ {
               add_header Cache-Control "public, max-age=43200, s-maxage=172800, stale-while-revalidate=86400, stale-if-error=604800";
               add_header Surrogate-Key "docs $1 $2 $1/$2";
@@ -110,17 +125,8 @@
         # /ja/search/ は rurema-search（サーバアプリ）から全バージョン対応の
         # 静的検索ページに置き換えた（rurema/generated-documents の
         # html/ja/search を system/bc-static-all が rsync し、他の版と同じく
-        # location / の root から配信される）。
-        # 旧 rurema-search の /ja/search/query:語/ 形式は ?q= に読み替えて
-        # リダイレクトする。version: 等の他のファセットは落とす（静的ページは
-        # 全バージョン横断）。$request_uri ベースのキャプチャなので
-        # percent-encoding は保たれる
-        location ~ ^/ja/search/.*query: {
-            if ($request_uri ~ "^/ja/search/(?:[^?]*?/)??query:([^/?]+)") {
-                return 301 /ja/search/?q=$1;
-            }
-            return 301 /ja/search/;
-        }
+        # location / の root から配信される。query: URL の互換リダイレクトは
+        # location / 内のネスト location を参照）
 
         error_page   500 502 503 504  /50x.html;
         location = /50x.html {

--- a/public/en/index.html
+++ b/public/en/index.html
@@ -24,10 +24,10 @@
     <a class="list-group-item" href="./4.0/">Ruby 4.0</a>
     <a class="list-group-item" href="./3.4/">Ruby 3.4</a>
     <a class="list-group-item" href="./3.3/">Ruby 3.3</a>
-    <a class="list-group-item" href="./3.2/">Ruby 3.2</a>
   </div>
   <h2>Other versions</h2>
   <div class="list-group">
+    <a class="list-group-item" href="./3.2/">Ruby 3.2 (End of Support 2026-04)</a>
     <a class="list-group-item" href="./3.1/">Ruby 3.1 (End of Support 2025-04)</a>
     <a class="list-group-item" href="./3.0/">Ruby 3.0 (End of Support 2024-04)</a>
     <a class="list-group-item" href="./2.7.0/">Ruby 2.7 (End of Support 2023-04)</a>

--- a/public/en/index.html
+++ b/public/en/index.html
@@ -37,6 +37,7 @@
     <a class="list-group-item" href="./2.3.0/">Ruby 2.3 (End of Support 2019-04)</a>
     <a class="list-group-item" href="./2.2.0/">Ruby 2.2 (End of Support 2018-04)</a>
     <a class="list-group-item" href="./2.1.0/">Ruby 2.1 (End of Support 2017-04)</a>
+    <a class="list-group-item" href="./2.0.0/">Ruby 2.0.0 (End of Support 2016-02)</a>
   </div>
 </div>
 </body>

--- a/public/ja/index.html
+++ b/public/ja/index.html
@@ -48,6 +48,9 @@
     <a class="list-group-item" href="./2.3.0/doc/index.html">Ruby 2.3 (2019-04 サポート終了)</a>
     <a class="list-group-item" href="./2.2.0/doc/index.html">Ruby 2.2 (2018-04 サポート終了)</a>
     <a class="list-group-item" href="./2.1.0/doc/index.html">Ruby 2.1 (2017-04 サポート終了)</a>
+    <a class="list-group-item" href="./2.0.0/doc/index.html">Ruby 2.0.0 (2016-02 サポート終了)</a>
+    <a class="list-group-item" href="./1.9.3/doc/index.html">Ruby 1.9.3 (2015-02 サポート終了)</a>
+    <a class="list-group-item" href="./1.8.7/doc/index.html">Ruby 1.8.7 (2014-07 サポート終了)</a>
     <a class="list-group-item" href="https://rurema.clear-code.com/">https://rurema.clear-code.com/</a>
   </div>
   <h2>Project Page</h2>

--- a/public/ja/index.html
+++ b/public/ja/index.html
@@ -27,7 +27,6 @@
     <a class="list-group-item" href="./4.0/doc/index.html">Ruby 4.0</a>
     <a class="list-group-item" href="./3.4/doc/index.html">Ruby 3.4</a>
     <a class="list-group-item" href="./3.3/doc/index.html">Ruby 3.3</a>
-    <a class="list-group-item" href="./3.2/doc/index.html">Ruby 3.2</a>
 <!--
     <div class="list-group-item list-group-item-info">
       <strong>注：</strong> Rubyは2.1.0から<a href='https://www.ruby-lang.org/ja/news/2013/12/21/ruby-version-policy-changes-with-2-1-0/'>Semantic Versioning</a>を採用しています。
@@ -39,6 +38,7 @@
   <h2>Other versions</h2>
   <div class="list-group">
     <a class="list-group-item" href="./master/doc/index.html">Ruby 開発版</a>
+    <a class="list-group-item" href="./3.2/doc/index.html">Ruby 3.2 (2026-04 サポート終了)</a>
     <a class="list-group-item" href="./3.1/doc/index.html">Ruby 3.1 (2025-04 サポート終了)</a>
     <a class="list-group-item" href="./3.0/doc/index.html">Ruby 3.0 (2024-04 サポート終了)</a>
     <a class="list-group-item" href="./2.7.0/doc/index.html">Ruby 2.7 (2023-04 サポート終了)</a>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,2 @@
 User-Agent: *
-Disallow: /ja/search/
+Disallow:


### PR DESCRIPTION
## 概要

/ja/ と /en/ のバージョン一覧と robots.txt の更新です（3 コミット、それぞれ独立に取捨可能）。

1. **古いバージョンを一覧に追加**
   - ja: 凍結版 1.8.7 / 1.9.3 / 2.0.0。rurema/generated-documents の
     FROZEN_VERSIONS として静的 HTML が配信中で
     （`/ja/1.8.7/doc/index.html` 等が応答することを確認済み）、
     `/ja/search/` の検索対象にも含まれていますが、一覧からだけ漏れていました。
   - en: 2.0.0 のみ（`/en/2.0.0/` 応答確認済み）。`/en/1.8.7/` と
     `/en/1.9.3/` は linked_dirs でディレクトリだけ存在し中身が空のため
     追加していません。
2. **Ruby 3.2 を「Other versions」（サポート終了）の節へ移動（ja / en とも）**。
   3.2 は 2026-04-01 に EOL 済みで、`/ja/3.2/` の各ページには既に
   EOL 警告バナーが出ています（一覧だけが現役扱いのままでした）。
3. **robots.txt の `Disallow: /ja/search/` を撤廃**。この Disallow は
   サーバーサイド検索（rurema-search）へのクロール負荷対策でしたが、
   #191 で静的なクライアントサイド検索ページに置き換え済みのため
   不要になりました。

サポート終了月は ruby/www.ruby-lang.org の `_data/branches.yml` に
基づきます（branches.yml に無い 1.8.7 のみ 2014-07-01 の
[EOL 告知](https://www.ruby-lang.org/ja/news/2014/07/01/eol-for-1-8-7-and-1-9-2/)）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
