### PR TITLE
linked_dirs から中身のない public/en/1.8.7 と public/en/1.9.3 を外す

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -6,12 +6,15 @@ set :default_env, {
   'PATH' => '/snap/bin:$PATH',
   'DEBIAN_DISABLE_RUBYGEMS_INTEGRATION' => 'true',
 }
-versions = %w[
+ja_versions = %w[
   1.8.7 1.9.3
   2.0.0 2.1.0 2.2.0 2.3.0 2.4.0 2.5.0 2.6.0 2.7.0
   3.0 3.1 3.2 3.3 3.4
   4.0
   master
 ]
+# /en/ の 1.8.7 と 1.9.3 は配信できる中身がない（英語版ドキュメントの
+# アーカイブは 2.0.0 以降のみ）ため linked_dirs に含めない
+en_versions = ja_versions - %w[1.8.7 1.9.3]
 master_version = '4.1'
-set :linked_dirs, ["sources", "public/ja/#{master_version}", "public/ja/latest", "public/ja/search"] + versions.map{|v| ["public/en/#{v}", "public/ja/#{v}"]}.flatten
+set :linked_dirs, ["sources", "public/ja/#{master_version}", "public/ja/latest", "public/ja/search"] + en_versions.map{|v| "public/en/#{v}"} + ja_versions.map{|v| "public/ja/#{v}"}


### PR DESCRIPTION
## 概要

`config/deploy.rb` の linked_dirs から `public/en/1.8.7` と
`public/en/1.9.3` を外します。

英語版ドキュメントのアーカイブ（cache.ruby-lang.org の `ruby-docs-en-*`）は
2.0.0 以降しか存在せず、この 2 つは linked_dirs の指定によって
**空ディレクトリが作られているだけ**でした（2016-01 作成のまま空。
そのため `/en/1.8.7/` 等へのアクセスは 404 ではなく 403 になっていました）。

versions 配列を `ja_versions` に改名し、en 側は
`en_versions = ja_versions - %w[1.8.7 1.9.3]` で生成します。
変更前後の linked_dirs を突き合わせて、差分が上記 2 エントリの削除のみ
（38 → 36 件）であることを確認済みです。

## 反映後

- 次回デプロイからリリース内にシンボリックリンクが作られなくなり、
  `/en/1.8.7/`・`/en/1.9.3/` は 403 ではなく 404 になります
- `shared/public/en/{1.8.7,1.9.3}` の空ディレクトリ自体は残るため、
  不要なら手動で削除してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)
