### PR TITLE
Clarify that /ja content is managed in a separate repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,13 @@ The English Ruby documentation is automatically generated and updated through a 
 
 ## How docs.ruby-lang.org/ja Works
 
+This repository does not contain the Japanese documentation content, and pull requests to `/ja` pages should not be opened here. The Japanese Ruby documentation (Rurema) has its own source repositories:
+
+- [rurema/doctree](https://github.com/rurema/doctree) — the source documents. This is where to send fixes for the content of `/ja` pages (each page also links to its source file for editing).
+- [rurema/bitclust](https://github.com/rurema/bitclust) — the tool that parses and renders the documentation.
+
+This repository is only responsible for `en/` content and the deployment infrastructure that publishes both `en/` and `ja/` to docs.ruby-lang.org, described below.
+
 The Japanese Ruby documentation (Rurema) is automatically generated and updated through a pipeline involving GitHub repositories, systemd services, and BitClust tool. Here's how it all comes together:
 
 1. **Documentation Generation and Upload**


### PR DESCRIPTION
## Summary

- `CONTRIBUTING.md` explains the `docs.ruby-lang.org/ja` deployment pipeline, but never states where to actually send fixes for the Japanese documentation *content*. Contributors could reasonably open a pull request against this repository for a `/ja` page.
- Add a short note at the top of the "How docs.ruby-lang.org/ja Works" section pointing to [rurema/doctree](https://github.com/rurema/doctree) (source documents — where content fixes should go; each generated page also links back to its source file for editing) and [rurema/bitclust](https://github.com/rurema/bitclust) (the tooling), and clarify that this repository is only responsible for `en/` content plus the deployment infrastructure for both `en/` and `ja/`.
- No changes to the existing pipeline description; the note is additive and doesn't contradict anything already documented there.

## Test plan

- [x] Rendered the updated `CONTRIBUTING.md` section locally and confirmed the Markdown and links are well-formed.
- N/A — documentation-only change, no build/test pipeline affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
